### PR TITLE
feat: add Upwork proposal builder app

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    "@next/next/no-img-element": "off"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# proposals

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# proposals
+# Upwork Proposal Builder
+
+A Next.js + TypeScript workspace for drafting Upwork proposals with TipTap, Tailwind, shadcn-inspired UI, and Upwork-safe copy workflows. The editor keeps formatting inside Upwork, ships a plain-text fallback, and includes templates, snippets, and a quality assistant.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+Open http://localhost:3000 to use the editor. Autosave persists in the current browser.
+
+## Available scripts
+
+- `npm run dev` – start the Next.js dev server
+- `npm run build` – create a production build
+- `npm run start` – run the production server
+- `npm run lint` – run Next.js ESLint rules
+- `npm run test` – execute Vitest unit tests for sanitisation, clipboard payloads, and the plain-text renderer
+
+## Features
+
+- TipTap editor restricted to Upwork-safe tags and smart keyboard shortcuts
+- Toolbar for bold, italic, underline, lists, blockquotes, code, links, emoji picker, and clear formatting
+- Upwork preview vs plain-text fallback toggle with copy buttons for each mode
+- Templates, variable slots, snippets library, and quality assistant with score dial, spam detector, and readability metrics
+- Paste-test sandbox and “How to paste into Upwork” helper page
+
+## Testing
+
+Run `npm run test` to ensure sanitisation, clipboard payloads, and the plain-text renderer behave as expected.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "proposals",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@tiptap/extension-character-count": "^2.1.0",
+    "@tiptap/extension-link": "^2.1.0",
+    "@tiptap/extension-placeholder": "^2.1.0",
+    "@tiptap/extension-underline": "^2.1.0",
+    "@tiptap/react": "^2.1.0",
+    "@tiptap/starter-kit": "^2.1.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "dompurify": "^3.0.9",
+    "next": "14.2.4",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "reading-time": "^1.2.0",
+    "tailwind-merge": "^2.2.1",
+    "zustand": "^4.5.2",
+    "lucide-react": "^0.378.0",
+    "sonner": "^1.5.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/node": "^20.12.7",
+    "@types/react": "^18.2.79",
+    "@types/react-dom": "^18.2.19",
+    "autoprefixer": "^10.4.17",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "14.2.4",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0",
+    "tailwindcss-animate": "^1.0.7",
+    "jsdom": "^24.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,39 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 47.4% 11.2%;
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+  --border: 214.3 31.8% 91.4%;
+  --ring: 215 20.2% 65.1%;
+}
+
+.dark {
+  --background: 222.2 84% 4.9%;
+  --foreground: 210 40% 98%;
+  --muted: 217.2 32.6% 17.5%;
+  --muted-foreground: 215 20.2% 65.1%;
+  --accent: 217.2 32.6% 17.5%;
+  --accent-foreground: 210 40% 98%;
+  --border: 217.2 32.6% 17.5%;
+  --ring: 212.7 26.8% 83.9%;
+}
+
+body {
+  @apply bg-background text-foreground antialiased;
+}
+
+.prose ul,
+.prose ol {
+  margin: 0;
+  padding-left: 1.5rem;
+}
+
+.prose li {
+  margin: 0.25rem 0;
+}

--- a/src/app/how-to/page.tsx
+++ b/src/app/how-to/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "How to Paste into Upwork",
+  description: "Step-by-step guide for testing and pasting your proposal into Upwork."
+};
+
+const steps = [
+  {
+    title: "Draft and polish",
+    body:
+      "Use the editor to complete every section. Keep an eye on the character limit, grade level, and quality hints."
+  },
+  {
+    title: "Preview like Upwork",
+    body:
+      "Toggle the Upwork Preview panel and the Plain-Text fallback. Make sure links show the URL and lists look right."
+  },
+  {
+    title: "Copy with one click",
+    body:
+      "Use \"Copy Upwork-Safe HTML\". It writes both HTML and plain text to your clipboard in case Upwork strips tags."
+  },
+  {
+    title: "Paste and verify",
+    body:
+      "Paste into the Upwork proposal editor. If it looks off, use the Paste-Test helper on the main page to debug."
+  }
+];
+
+export default function HowToPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">How to paste into Upwork</h1>
+        <p className="text-sm text-muted-foreground">
+          Follow these quick checkpoints and the proposal will survive every Upwork editor.
+        </p>
+      </div>
+      <ol className="space-y-4 text-sm">
+        {steps.map((step, index) => (
+          <li
+            key={step.title}
+            className="rounded-lg border border-border bg-background p-4 shadow-sm"
+          >
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Step {index + 1}
+            </div>
+            <h2 className="mt-1 text-lg font-semibold">{step.title}</h2>
+            <p className="mt-2 text-muted-foreground">{step.body}</p>
+          </li>
+        ))}
+      </ol>
+      <p className="text-sm text-muted-foreground">
+        Ready to build? <Link href="/" className="font-medium text-foreground underline">Back to the editor</Link>.
+      </p>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import Link from "next/link";
+import "./globals.css";
+import { Toaster } from "sonner";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
+
+export const metadata: Metadata = {
+  title: "Upwork Proposal Builder",
+  description:
+    "Compose Upwork proposals with perfect formatting, instant previews, and one-click copy."
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${inter.variable} font-sans`}>
+        <Toaster richColors position="top-right" />
+        <div className="min-h-screen bg-background text-foreground">
+          <header className="border-b border-border bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+            <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
+              <Link href="/" className="text-sm font-semibold uppercase tracking-wide">
+                Proposal Lab
+              </Link>
+              <nav className="flex items-center gap-4 text-sm text-muted-foreground">
+                <Link href="/" className="hover:text-foreground">
+                  Editor
+                </Link>
+                <Link href="/how-to" className="hover:text-foreground">
+                  How to paste
+                </Link>
+              </nav>
+            </div>
+          </header>
+          <main className="mx-auto max-w-6xl px-4 py-10">{children}</main>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,5 @@
+import { ProposalEditor } from "@/components/proposal-editor";
+
+export default function HomePage() {
+  return <ProposalEditor />;
+}

--- a/src/components/clipboard-button.tsx
+++ b/src/components/clipboard-button.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { copyToClipboard, buildClipboardPayload } from "@/utils/clipboard";
+import { toast } from "sonner";
+
+type ClipboardButtonProps = {
+  html: string;
+  mode: "html" | "text";
+};
+
+export function ClipboardButton({ html, mode }: ClipboardButtonProps) {
+  const label = mode === "html" ? "Copy Upwork-Safe HTML" : "Copy Styled Plain Text";
+
+  const handleCopy = async () => {
+    try {
+      if (mode === "html") {
+        await copyToClipboard(html);
+      } else {
+        const payload = buildClipboardPayload(html);
+        if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(payload.text);
+        } else {
+          throw new Error("Clipboard plain text API unavailable");
+        }
+      }
+      toast.success(`${label} copied`);
+    } catch (error) {
+      console.error(error);
+      toast.error("Clipboard copy failed. Copy manually as a fallback.");
+    }
+  };
+
+  return (
+    <Button type="button" onClick={handleCopy} variant="default">
+      {label}
+    </Button>
+  );
+}

--- a/src/components/paste-tester.tsx
+++ b/src/components/paste-tester.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import * as React from "react";
+import { sanitizeForPreview } from "@/utils/html";
+
+export function PasteTester() {
+  const [preview, setPreview] = React.useState("");
+  const sandboxRef = React.useRef<HTMLDivElement>(null);
+
+  const handlePaste = (event: React.ClipboardEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const html = event.clipboardData.getData("text/html");
+    const text = event.clipboardData.getData("text/plain");
+    const next = html || text;
+    const sanitized = sanitizeForPreview(next);
+    setPreview(sanitized);
+    if (sandboxRef.current) {
+      sandboxRef.current.innerHTML = sanitized;
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-lg border border-dashed border-border p-4">
+      <div className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+        Paste-test helper
+      </div>
+      <div
+        ref={sandboxRef}
+        onPaste={handlePaste}
+        contentEditable
+        suppressContentEditableWarning
+        className="min-h-[120px] rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none"
+      >
+        Paste here to simulate Upwork’s sanitiser.
+      </div>
+      <div className="prose prose-sm max-w-none text-muted-foreground">
+        <p className="text-xs">Sanitized preview:</p>
+        <div dangerouslySetInnerHTML={{ __html: preview }} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/proposal-editor.tsx
+++ b/src/components/proposal-editor.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import * as React from "react";
+import { useEditor, EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Underline from "@tiptap/extension-underline";
+import Link from "@tiptap/extension-link";
+import Placeholder from "@tiptap/extension-placeholder";
+import CharacterCount from "@tiptap/extension-character-count";
+import { Toolbar } from "@/components/toolbar";
+import { TemplatePicker } from "@/components/template-picker";
+import { VariablesPanel } from "@/components/variables-panel";
+import { SnippetsDrawer } from "@/components/snippets-drawer";
+import { QualityHints } from "@/components/quality-hints";
+import { SanitizedPreview } from "@/components/sanitized-preview";
+import { ClipboardButton } from "@/components/clipboard-button";
+import { PasteTester } from "@/components/paste-tester";
+import { SettingsDialog } from "@/components/settings-dialog";
+import { useProposalStore } from "@/store/use-proposal-store";
+import { analyzeContent } from "@/utils/analysis";
+import { sanitizeHtml } from "@/utils/html";
+import { htmlToPlainText } from "@/utils/plain-text";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const CHAR_LIMIT = 5000;
+
+export function ProposalEditor() {
+  const html = useProposalStore((state) => state.html);
+  const setHtml = useProposalStore((state) => state.setHtml);
+  const [viewMode, setViewMode] = React.useState<"preview" | "plaintext">("preview");
+
+  const editor = useEditor({
+    content: html || "<p></p>",
+    extensions: [
+      StarterKit.configure({
+        heading: false,
+        dropcursor: {
+          class: "tiptap-dropcursor"
+        },
+        horizontalRule: false,
+        strike: false,
+        history: true
+      }),
+      Underline,
+      Link.configure({
+        openOnClick: false,
+        autolink: true,
+        linkOnPaste: true,
+        HTMLAttributes: {
+          rel: "nofollow noopener",
+          target: "_blank"
+        }
+      }),
+      Placeholder.configure({
+        placeholder:
+          "Craft your hook, proof, plan, CTA… Smart shortcuts like **bold** and 1. start lists."
+      }),
+      CharacterCount.configure({ limit: CHAR_LIMIT + 1000 })
+    ],
+    editorProps: {
+      attributes: {
+        class:
+          "prose prose-sm dark:prose-invert focus:outline-none min-h-[480px] leading-relaxed"
+      }
+    },
+    onUpdate: ({ editor: instance }) => {
+      const html = instance.getHTML();
+      setHtml(html);
+    }
+  });
+
+  React.useEffect(() => {
+    if (!editor) return;
+    if (html && html !== editor.getHTML()) {
+      editor.commands.setContent(html, false);
+    }
+  }, [editor, html]);
+
+  React.useEffect(() => {
+    if (!editor) return;
+    const interval = window.setInterval(() => {
+      setHtml(editor.getHTML());
+    }, 2000);
+    return () => window.clearInterval(interval);
+  }, [editor, setHtml]);
+
+  const safeHtml = React.useMemo(() => sanitizeHtml(html ?? ""), [html]);
+  const plainText = React.useMemo(() => htmlToPlainText(safeHtml), [safeHtml]);
+  const stats = React.useMemo(() => analyzeContent(plainText), [plainText]);
+
+  const handleTemplateApply = (html: string) => {
+    editor?.commands.setContent(html, false);
+    setHtml(html);
+  };
+
+  const insertContent = (content: string) => {
+    if (!editor) return;
+    const lines = content.split(/\n+/).map((line) => line.trim()).filter(Boolean);
+
+    if (
+      lines.length > 1 &&
+      lines.every((line) => line.startsWith("•") || /^\d+[.)]/.test(line))
+    ) {
+      const ordered = lines.every((line) => /^\d+[.)]/.test(line));
+      const listItems = lines
+        .map((line) => {
+          if (line.startsWith("•")) {
+            return `<li>${line.replace(/^•\s*/, "")}</li>`;
+          }
+          const match = line.match(/^(\d+)[.)]\s*(.*)$/);
+          return `<li>${match ? match[2] : line}</li>`;
+        })
+        .join("");
+      const listHtml = ordered ? `<ol>${listItems}</ol>` : `<ul>${listItems}</ul>`;
+      editor.chain().focus().insertContent(listHtml).run();
+      return;
+    }
+
+    const htmlBlock = `<p>${content}</p>`;
+    editor.chain().focus().insertContent(htmlBlock).run();
+  };
+
+  const charactersUsed = stats.characterCount;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">Proposal Builder</h1>
+          <p className="text-sm text-muted-foreground">
+            Write once → paste once → Upwork keeps your formatting.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <ClipboardButton html={safeHtml} mode="html" />
+          <ClipboardButton html={safeHtml} mode="text" />
+          <SettingsDialog />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1.8fr)_minmax(0,1fr)]">
+        <div className="space-y-4">
+          <Toolbar editor={editor} />
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                Editor
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="rounded-lg border border-border bg-background p-4 shadow-inner">
+                <EditorContent editor={editor} />
+              </div>
+              <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+                <span>
+                  {stats.wordCount} words • {charactersUsed}/{CHAR_LIMIT} characters
+                </span>
+                {charactersUsed > CHAR_LIMIT ? (
+                  <span className="text-red-500">⚠️ Upwork trims after {CHAR_LIMIT} characters.</span>
+                ) : null}
+                <span>{stats.sentences} sentences • {stats.readTimeMinutes} min read</span>
+              </div>
+            </CardContent>
+          </Card>
+          <div className="flex flex-wrap gap-3">
+            <Button
+              type="button"
+              variant={viewMode === "preview" ? "default" : "secondary"}
+              size="sm"
+              onClick={() => setViewMode("preview")}
+            >
+              Upwork preview
+            </Button>
+            <Button
+              type="button"
+              variant={viewMode === "plaintext" ? "default" : "secondary"}
+              size="sm"
+              onClick={() => setViewMode("plaintext")}
+            >
+              Plain-text fallback
+            </Button>
+          </div>
+          <div className="rounded-lg border border-border bg-background p-4 shadow-sm">
+            {viewMode === "preview" ? (
+              <SanitizedPreview html={safeHtml} />
+            ) : (
+              <pre className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">
+                {plainText}
+              </pre>
+            )}
+          </div>
+          <PasteTester />
+        </div>
+        <div className="space-y-4">
+          <TemplatePicker onApply={handleTemplateApply} />
+          <VariablesPanel />
+          <SnippetsDrawer onInsert={insertContent} />
+          <QualityHints
+            wordCount={stats.wordCount}
+            characterCount={charactersUsed}
+            readTimeMinutes={stats.readTimeMinutes}
+            gradeLevel={stats.gradeLevel}
+            avgSentenceLength={stats.avgSentenceLength}
+            spamMatches={stats.spamMatches}
+            hints={stats.hints}
+            score={stats.score}
+            emojiCount={stats.emojiCount}
+            charLimit={CHAR_LIMIT}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/quality-hints.tsx
+++ b/src/components/quality-hints.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import type { QualityInsight } from "@/utils/analysis";
+
+type QualityHintsProps = {
+  wordCount: number;
+  characterCount: number;
+  readTimeMinutes: number;
+  gradeLevel: number;
+  avgSentenceLength: number;
+  spamMatches: string[];
+  hints: QualityInsight[];
+  score: number;
+  emojiCount: number;
+  charLimit: number;
+};
+
+const getSeverityColor = (severity: QualityInsight["severity"]) => {
+  switch (severity) {
+    case "error":
+      return "text-red-500";
+    case "warn":
+      return "text-amber-500";
+    default:
+      return "text-slate-500";
+  }
+};
+
+export function QualityHints(props: QualityHintsProps) {
+  const {
+    wordCount,
+    characterCount,
+    readTimeMinutes,
+    gradeLevel,
+    avgSentenceLength,
+    spamMatches,
+    hints,
+    score,
+    emojiCount,
+    charLimit
+  } = props;
+
+  const charWarning = characterCount > charLimit;
+  const normalizedScore = Math.max(0, Math.min(100, score));
+
+  return (
+    <div className="rounded-lg border border-border bg-background p-4 shadow-sm">
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
+            <span><strong>{wordCount}</strong> words</span>
+            <span className={charWarning ? "text-red-500" : undefined}>
+              <strong>{characterCount}</strong> chars
+            </span>
+            <span>
+              <strong>{readTimeMinutes}</strong> min read
+            </span>
+            <span>
+              Grade <strong>{gradeLevel}</strong>
+            </span>
+            <span>
+              Avg sentence <strong>{avgSentenceLength}</strong>
+            </span>
+            <span>
+              Emojis <strong>{emojiCount}</strong>
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="relative h-16 w-16">
+              <svg viewBox="0 0 36 36" className="h-16 w-16">
+                <path
+                  className="text-muted-foreground/20"
+                  strokeWidth="4"
+                  stroke="currentColor"
+                  fill="none"
+                  strokeLinecap="round"
+                  d="M18 2a16 16 0 1 1 0 32 16 16 0 1 1 0-32"
+                />
+                <path
+                  className="text-foreground"
+                  strokeWidth="4"
+                  stroke="currentColor"
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeDasharray={`${normalizedScore}, 100`}
+                  d="M18 2a16 16 0 1 1 0 32 16 16 0 1 1 0-32"
+                />
+              </svg>
+              <div className="absolute inset-0 flex items-center justify-center text-sm font-semibold">
+                {normalizedScore}
+              </div>
+            </div>
+            <div className="text-xs text-muted-foreground uppercase tracking-wide">
+              Quality score
+            </div>
+          </div>
+        </div>
+        {spamMatches.length > 0 ? (
+          <div className="rounded-md bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:bg-amber-500/10 dark:text-amber-200">
+            ⚠️ Spam trigger phrases: {spamMatches.join(", ")}
+          </div>
+        ) : null}
+        {hints.length > 0 ? (
+          <ul className="space-y-2 text-sm">
+            {hints.map((hint) => (
+              <li key={hint.id} className={getSeverityColor(hint.severity)}>
+                • {hint.label}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            ✅ Looking good! Structure, CTA, and readability are on point.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/sanitized-preview.tsx
+++ b/src/components/sanitized-preview.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import * as React from "react";
+import { sanitizeForPreview } from "@/utils/html";
+
+export function SanitizedPreview({ html }: { html: string }) {
+  const [clean, setClean] = React.useState(() => sanitizeForPreview(html));
+
+  React.useEffect(() => {
+    setClean(sanitizeForPreview(html));
+  }, [html]);
+
+  return (
+    <div
+      className="prose prose-sm max-w-none dark:prose-invert"
+      dangerouslySetInnerHTML={{ __html: clean }}
+    />
+  );
+}

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Settings } from "lucide-react";
+
+const STORAGE_KEY = "proposal-theme";
+
+export function SettingsDialog() {
+  const [open, setOpen] = React.useState(false);
+  const [darkMode, setDarkMode] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "dark") {
+      setDarkMode(true);
+      document.documentElement.classList.add("dark");
+    }
+  }, []);
+
+  const toggleDarkMode = (value: boolean) => {
+    setDarkMode(value);
+    document.documentElement.classList.toggle("dark", value);
+    localStorage.setItem(STORAGE_KEY, value ? "dark" : "light");
+  };
+
+  React.useEffect(() => {
+    if (!open) return;
+
+    function handleClick(event: MouseEvent) {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex items-center gap-2"
+      >
+        <Settings className="h-4 w-4" />
+        Settings
+      </Button>
+      {open ? (
+        <div className="absolute right-0 z-20 mt-2 w-64 rounded-lg border border-border bg-background p-4 text-sm shadow-xl">
+          <div className="flex items-center justify-between">
+            <span>Dark mode</span>
+            <Switch checked={darkMode} onCheckedChange={toggleDarkMode} />
+          </div>
+          <p className="mt-3 text-xs text-muted-foreground">
+            Autosave runs every few seconds and persists in this browser.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/snippets-drawer.tsx
+++ b/src/components/snippets-drawer.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { snippets } from "@/data/snippets";
+import { Button } from "@/components/ui/button";
+
+export function SnippetsDrawer({ onInsert }: { onInsert: (snippet: string) => void }) {
+  const grouped = snippets.reduce<Record<string, typeof snippets>>(
+    (acc, snippet) => {
+      acc[snippet.category] = acc[snippet.category] ?? [];
+      acc[snippet.category].push(snippet);
+      return acc;
+    },
+    {}
+  );
+
+  return (
+    <div className="space-y-3 rounded-lg border border-border bg-background p-4 shadow-sm">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+        Snippets
+      </h3>
+      <div className="space-y-4 text-sm">
+        {Object.entries(grouped).map(([category, list]) => (
+          <div key={category} className="space-y-2">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {category}
+            </div>
+            <div className="space-y-2">
+              {list.map((snippet) => (
+                <div
+                  key={snippet.id}
+                  className="rounded-md border border-dashed border-border p-3"
+                >
+                  <div className="mb-2 font-medium">{snippet.name}</div>
+                  <p className="text-muted-foreground">{snippet.content}</p>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    className="mt-3"
+                    onClick={() => onInsert(snippet.content)}
+                  >
+                    Insert
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/template-picker.tsx
+++ b/src/components/template-picker.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { templates, sectionsOrder } from "@/data/templates";
+import { useProposalStore } from "@/store/use-proposal-store";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+
+export function TemplatePicker({ onApply }: { onApply: (html: string) => void }) {
+  const sections = useProposalStore((state) => state.sections);
+  const toggleSection = useProposalStore((state) => state.toggleSection);
+  const applyTemplate = useProposalStore((state) => state.applyTemplate);
+  const selectedTemplateId = useProposalStore((state) => state.selectedTemplateId);
+  const setHtml = useProposalStore((state) => state.setHtml);
+  const setSelectedTemplate = useProposalStore((state) => state.setSelectedTemplate);
+
+  const handleTemplate = (templateId: string) => {
+    const template = templates.find((item) => item.id === templateId);
+    if (!template) return;
+    const html = applyTemplate(template);
+    onApply(html);
+  };
+
+  const handleScaffold = () => {
+    const scaffold = [
+      "Hook → write a custom opener",
+      "Credibility snapshot → results & proof",
+      "Questions → ask 1-2 specifics",
+      "Game plan → outline next 3 moves",
+      "CTA → invite action",
+      "P.S. → bonus insight"
+    ]
+      .map((line) => `<p>${line}</p>`)
+      .join("\n");
+    setHtml(scaffold);
+    setSelectedTemplate(undefined);
+    onApply(scaffold);
+  };
+
+  return (
+    <div className="space-y-3 rounded-lg border border-border bg-background p-4 shadow-sm">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Templates
+        </h3>
+        <Button type="button" size="sm" variant="secondary" onClick={handleScaffold}>
+          Insert scaffold
+        </Button>
+      </div>
+      <div className="space-y-3">
+        {templates.map((template) => (
+          <button
+            key={template.id}
+            type="button"
+            onClick={() => handleTemplate(template.id)}
+            className={`w-full rounded-md border px-3 py-2 text-left text-sm transition hover:border-foreground/40 ${
+              selectedTemplateId === template.id
+                ? "border-foreground bg-foreground/5"
+                : "border-border"
+            }`}
+          >
+            <div className="font-medium">
+              {template.emoji} {template.name}
+            </div>
+            <p className="text-xs text-muted-foreground">{template.description}</p>
+          </button>
+        ))}
+      </div>
+      <div className="space-y-2 pt-2">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Sections
+        </p>
+        <ul className="space-y-2 text-sm">
+          {sectionsOrder.map((section) => {
+            const label =
+              section === "ps"
+                ? "P.S."
+                : section
+                    .replace(/-/g, " ")
+                    .replace(/\b\w/g, (char) => char.toUpperCase());
+            return (
+              <li key={section} className="flex items-center justify-between">
+                <span>{label}</span>
+                <Switch
+                  checked={sections[section]}
+                  onCheckedChange={() => toggleSection(section)}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import * as React from "react";
+import type { Editor } from "@tiptap/react";
+import {
+  Bold,
+  Italic,
+  Underline as UnderlineIcon,
+  List,
+  ListOrdered,
+  Quote,
+  Code,
+  Link,
+  Eraser,
+  Smile
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { emojiList } from "@/data/spam";
+
+type ToolbarProps = {
+  editor: Editor | null;
+};
+
+export function Toolbar({ editor }: ToolbarProps) {
+  const [showEmoji, setShowEmoji] = React.useState(false);
+  const emojiButtonRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        showEmoji &&
+        emojiButtonRef.current &&
+        !emojiButtonRef.current.contains(event.target as Node)
+      ) {
+        setShowEmoji(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [showEmoji]);
+
+  if (!editor) return null;
+
+  const applyLink = () => {
+    const previous = editor.getAttributes("link").href as string | undefined;
+    const url = window.prompt("Link URL", previous ?? "https://");
+    if (url === null) return;
+    if (url.trim() === "") {
+      editor.chain().focus().extendMarkRange("link").unsetLink().run();
+      return;
+    }
+    try {
+      const sanitizedUrl = new URL(url.trim());
+      editor
+        .chain()
+        .focus()
+        .extendMarkRange("link")
+        .setLink({ href: sanitizedUrl.toString(), target: "_blank", rel: "nofollow noopener" })
+        .run();
+    } catch {
+      window.alert("Please enter a valid URL including https://");
+    }
+  };
+
+  const insertEmoji = (emoji: string) => {
+    editor.chain().focus().insertContent(emoji + " ").run();
+    setShowEmoji(false);
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-background/90 p-2 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-background/80">
+      <Button
+        type="button"
+        size="sm"
+        variant={editor.isActive("bold") ? "default" : "secondary"}
+        onClick={() => editor.chain().focus().toggleBold().run()}
+      >
+        <Bold className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        variant={editor.isActive("italic") ? "default" : "secondary"}
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+      >
+        <Italic className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        variant={editor.isActive("underline") ? "default" : "secondary"}
+        onClick={() => editor.chain().focus().toggleUnderline().run()}
+      >
+        <UnderlineIcon className="h-4 w-4" />
+      </Button>
+      <div className="h-6 w-px bg-border" aria-hidden />
+      <Button
+        type="button"
+        size="sm"
+        variant={editor.isActive("bulletList") ? "default" : "secondary"}
+        onClick={() => editor.chain().focus().toggleBulletList().run()}
+      >
+        <List className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        variant={editor.isActive("orderedList") ? "default" : "secondary"}
+        onClick={() => editor.chain().focus().toggleOrderedList().run()}
+      >
+        <ListOrdered className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        variant={editor.isActive("blockquote") ? "default" : "secondary"}
+        onClick={() => editor.chain().focus().toggleBlockquote().run()}
+      >
+        <Quote className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        variant={editor.isActive("code") ? "default" : "secondary"}
+        onClick={() => editor.chain().focus().toggleCode().run()}
+      >
+        <Code className="h-4 w-4" />
+      </Button>
+      <Button type="button" size="sm" variant="secondary" onClick={applyLink}>
+        <Link className="h-4 w-4" />
+      </Button>
+      <div ref={emojiButtonRef} className="relative">
+        <Button
+          type="button"
+          size="sm"
+          variant={showEmoji ? "default" : "secondary"}
+          onClick={() => setShowEmoji((prev) => !prev)}
+        >
+          <Smile className="h-4 w-4" />
+        </Button>
+        {showEmoji ? (
+          <div className="absolute right-0 z-10 mt-2 flex w-40 flex-wrap gap-2 rounded-md border border-border bg-background p-3 shadow-xl">
+            {emojiList.map((emoji) => (
+              <button
+                key={emoji}
+                type="button"
+                className="text-lg"
+                onClick={() => insertEmoji(emoji)}
+              >
+                {emoji}
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
+      <div className="h-6 w-px bg-border" aria-hidden />
+      <Button
+        type="button"
+        size="sm"
+        variant="secondary"
+        onClick={() => editor.chain().focus().clearNodes().unsetAllMarks().run()}
+      >
+        <Eraser className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-foreground text-background",
+        outline: "text-foreground"
+      }
+    },
+    defaultVariants: {
+      variant: "default"
+    }
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+export function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+type ButtonElement = HTMLButtonElement;
+
+type ButtonProps = React.ButtonHTMLAttributes<ButtonElement> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  };
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-foreground text-background hover:bg-foreground/90",
+        outline:
+          "border border-input bg-background hover:bg-muted hover:text-foreground",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-muted text-muted-foreground hover:bg-muted/80",
+        destructive: "bg-red-500 text-white hover:bg-red-500/90",
+        link: "text-primary underline-offset-4 hover:underline"
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9"
+      }
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default"
+    }
+  }
+);
+
+const Button = React.forwardRef<ButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Component = asChild ? (React.Fragment as unknown as any) : "button";
+
+    if (asChild) {
+      return (
+        <Component>
+          <button
+            ref={ref}
+            className={cn(buttonVariants({ variant, size, className }))}
+            {...props}
+          />
+        </Component>
+      );
+    }
+
+    return (
+      <button
+        ref={ref}
+        className={cn(buttonVariants({ variant, size, className }))}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-xl border border-border bg-background p-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+export const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+export const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3 ref={ref} className={cn("text-lg font-semibold", className)} {...props} />
+));
+CardTitle.displayName = "CardTitle";
+
+export const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+export const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("mt-4 space-y-4", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+export const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("mt-6 flex items-center", className)} {...props} />
+));
+CardFooter.displayName = "CardFooter";

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type = "text", ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface SwitchProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onChange"> {
+  checked?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+}
+
+export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
+  ({ checked = false, onCheckedChange, className, ...props }, ref) => {
+    return (
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        data-state={checked ? "checked" : "unchecked"}
+        onClick={() => onCheckedChange?.(!checked)}
+        ref={ref}
+        className={cn(
+          "relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          checked && "bg-foreground",
+          className
+        )}
+        {...props}
+      >
+        <span
+          className={cn(
+            "pointer-events-none inline-block h-4 w-4 transform rounded-full bg-background shadow transition-all",
+            checked ? "translate-x-4" : "translate-x-0.5"
+          )}
+        />
+      </button>
+    );
+  }
+);
+Switch.displayName = "Switch";

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/src/components/variables-panel.tsx
+++ b/src/components/variables-panel.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { useProposalStore } from "@/store/use-proposal-store";
+
+export function VariablesPanel() {
+  const variables = useProposalStore((state) => state.variables);
+  const setVariable = useProposalStore((state) => state.setVariable);
+
+  const entries = Object.entries(variables);
+
+  return (
+    <div className="space-y-2 rounded-lg border border-border bg-background p-4 shadow-sm">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Variables
+        </h3>
+        <span className="text-xs text-muted-foreground">
+          Use like {{client_name}}
+        </span>
+      </div>
+      <div className="grid grid-cols-1 gap-3">
+        {entries.map(([key, value]) => (
+          <label key={key} className="space-y-1 text-sm">
+            <span className="font-medium capitalize">{key.replace(/_/g, " ")}</span>
+            <Input
+              value={value}
+              onChange={(event) => setVariable(key, event.target.value)}
+            />
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/data/snippets.ts
+++ b/src/data/snippets.ts
@@ -1,0 +1,36 @@
+export type Snippet = {
+  id: string;
+  name: string;
+  content: string;
+  category: "questions" | "risk" | "cta" | "portfolio";
+};
+
+export const snippets: Snippet[] = [
+  {
+    id: "discovery-questions",
+    name: "Discovery Questions",
+    category: "questions",
+    content:
+      "• What’s the single riskiest assumption about {{project_title}} right now?\n• How are you validating success after launch?\n• Any integrations or stakeholders I should loop in during week one?"
+  },
+  {
+    id: "risk-reversal",
+    name: "Risk Reversal",
+    category: "risk",
+    content:
+      "No-risk kickoff: first milestone scoped so you can evaluate momentum before green-lighting the rest."
+  },
+  {
+    id: "portfolio-blurb",
+    name: "Portfolio Blurb",
+    category: "portfolio",
+    content:
+      "Recent wins: scaled Next.js commerce for a DTC brand (35% conversion lift) and launched a Supabase CRM in 9 days."
+  },
+  {
+    id: "cta-audit",
+    name: "CTA — Audit",
+    category: "cta",
+    content: "Want me to record a Loom audit so you can see the first fixes before hiring?"
+  }
+];

--- a/src/data/spam.ts
+++ b/src/data/spam.ts
@@ -1,0 +1,12 @@
+export const spamPhrases = [
+  "guarantee",
+  "100%",
+  "best price",
+  "cheap",
+  "unlimited revisions",
+  "lowest bid",
+  "money back",
+  "super fast"
+];
+
+export const emojiList = ["✅", "🚀", "🧠", "🔧", "💡"];

--- a/src/data/templates.ts
+++ b/src/data/templates.ts
@@ -1,0 +1,101 @@
+export type TemplateSectionKey =
+  | "hook"
+  | "credibility"
+  | "questions"
+  | "plan"
+  | "cta"
+  | "ps";
+
+export type ProposalTemplate = {
+  id: string;
+  name: string;
+  description: string;
+  emoji: string;
+  sections: Record<TemplateSectionKey, string>;
+};
+
+export const defaultVariables: Record<string, string> = {
+  client_name: "there",
+  project_title: "your project",
+  deliverables: "key deliverables",
+  rate: "$20/hr",
+  eta: "7–10 days",
+  emoji_hook: "🚀"
+};
+
+const baseSections: Record<TemplateSectionKey, string> = {
+  hook:
+    "{{emoji_hook}} I reviewed {{project_title}} and spotted the same friction I solve on repeat.",
+  credibility:
+    "Quick cred: shipped {{deliverables}} for teams like Stripe Atlas & Calm; happy clients left 12 ⭐⭐⭐⭐⭐ notes.",
+  questions:
+    "Before I prescribe, can you clarify the current blockers and success criteria?",
+  plan:
+    "Game plan: (1) Audit current repo (2) Patch priority bugs (3) Ship tested handoff within {{eta}}.",
+  cta: "Want me to map the first 48 hours so you can see momentum fast?",
+  ps: "P.S. Share a repo slice and I’ll highlight two high-impact fixes before kickoff."
+};
+
+export const templates: ProposalTemplate[] = [
+  {
+    id: "next-rescue",
+    name: "Next.js Rescue / Fix & Finish",
+    description: "Stabilize and finish a half-built Next.js project.",
+    emoji: "🛠️",
+    sections: {
+      ...baseSections,
+      hook:
+        "🛠️ I combed through {{project_title}} — the unfinished flows match battles I've already won for VC-backed SaaS teams.",
+      plan:
+        "Rescue plan: (1) Sync on failing routes (2) Stabilize backend/API handoffs (3) Hard test + deploy in {{eta}} with a tidy changelog."
+    }
+  },
+  {
+    id: "supabase-setup",
+    name: "Supabase Expert Setup",
+    description: "Set up auth, storage, and automation on Supabase without duct tape.",
+    emoji: "🧱",
+    sections: {
+      ...baseSections,
+      hook:
+        "🧱 Your Supabase foundation can be production-hardened this week — I’ve rolled this stack for YC alumni repeatedly.",
+      plan:
+        "Setup path: (1) Model data + RLS (2) Auth flows + invites (3) Automations & QA with logging."
+    }
+  },
+  {
+    id: "ai-add-on",
+    name: "AI Feature Add-on",
+    description: "Ship a trustworthy AI feature inside an existing product.",
+    emoji: "🧠",
+    sections: {
+      ...baseSections,
+      hook:
+        "🧠 I build AI assistants that feel native — including retrieval-augmented chat and summarizers for remote teams.",
+      plan:
+        "Addon plan: (1) Outline the narrowest lovable workflow (2) Wire model + guardrails (3) Measure + iterate within {{eta}}."
+    }
+  },
+  {
+    id: "migrations-hardening",
+    name: "Migrations & Hardening",
+    description: "Clean migrations, env parity, and zero-downtime releases.",
+    emoji: "🛡️",
+    sections: {
+      ...baseSections,
+      hook:
+        "🛡️ I keep production calm during hairy migrations — think blue/green deploys and rollback-ready SQL scripts.",
+      plan:
+        "Hardening plan: (1) Map risk + rollback (2) Stage/test with synthetic data (3) Cutover with dashboards + alerts."
+    }
+  }
+];
+
+export const sectionsOrder: TemplateSectionKey[] = [
+  "hook",
+  "credibility",
+  "questions",
+  "plan",
+  "cta",
+  "ps"
+];

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/src/store/use-proposal-store.ts
+++ b/src/store/use-proposal-store.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import type { ProposalTemplate, TemplateSectionKey } from "@/data/templates";
+import { defaultVariables, sectionsOrder } from "@/data/templates";
+
+type ProposalState = {
+  html: string;
+  sections: Record<TemplateSectionKey, boolean>;
+  variables: Record<string, string>;
+  selectedTemplateId?: string;
+  lastSaved?: number;
+  setHtml: (html: string) => void;
+  toggleSection: (key: TemplateSectionKey) => void;
+  setVariable: (key: string, value: string) => void;
+  setSelectedTemplate: (id?: string) => void;
+  reset: () => void;
+  applyTemplate: (template: ProposalTemplate) => string;
+};
+
+const defaultSections = sectionsOrder.reduce(
+  (acc, key) => {
+    acc[key] = true;
+    return acc;
+  },
+  {} as Record<TemplateSectionKey, boolean>
+);
+
+export const useProposalStore = create<ProposalState>()(
+  persist(
+    (set, get) => ({
+      html: "",
+      sections: { ...defaultSections },
+      variables: { ...defaultVariables },
+      selectedTemplateId: undefined,
+      lastSaved: undefined,
+      setHtml: (html) => set({ html, lastSaved: Date.now() }),
+      toggleSection: (key) =>
+        set(({ sections }) => ({
+          sections: { ...sections, [key]: !sections[key] }
+        })),
+      setVariable: (key, value) =>
+        set(({ variables }) => ({
+          variables: { ...variables, [key]: value }
+        })),
+      setSelectedTemplate: (id) => set({ selectedTemplateId: id }),
+      reset: () =>
+        set({
+          html: "",
+          sections: { ...defaultSections },
+          variables: { ...defaultVariables },
+          selectedTemplateId: undefined
+        }),
+      applyTemplate: (template) => {
+        const { sections, variables } = get();
+        const resolved = sectionsOrder
+          .filter((key) => sections[key])
+          .map((key) => template.sections[key] ?? "")
+          .filter(Boolean)
+          .join("\n\n");
+
+        const mergedVariables = { ...defaultVariables, ...variables, emoji_hook: template.emoji };
+
+        const text = resolved.replace(/{{(.*?)}}/g, (_, token) => {
+          const lookup = token.trim().replace(/[^a-zA-Z0-9_]/g, "");
+          return mergedVariables[lookup] ?? `{{${lookup}}}`;
+        });
+
+        const html = text
+          .split(/\n{2,}/)
+          .map((block) => block.trim())
+          .filter(Boolean)
+          .map((block) => `<p>${block}</p>`)
+          .join("\n");
+
+        set({
+          html,
+          selectedTemplateId: template.id,
+          lastSaved: Date.now()
+        });
+
+        return html;
+      }
+    }),
+    {
+      name: "proposal-writer",
+      storage: createJSONStorage(() => localStorage),
+      partialize: ({ html, sections, variables, selectedTemplateId }) => ({
+        html,
+        sections,
+        variables,
+        selectedTemplateId
+      })
+    }
+  )
+);

--- a/src/tests/clipboard.test.ts
+++ b/src/tests/clipboard.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { buildClipboardPayload } from "@/utils/clipboard";
+
+const sample = `<p><strong>Hello</strong> there</p><ul><li>• item</li></ul>`;
+
+describe("buildClipboardPayload", () => {
+  it("returns sanitized html and markdown-like plain text", () => {
+    const payload = buildClipboardPayload(sample);
+    expect(payload.html).toContain("<strong>Hello</strong>");
+    expect(payload.html).not.toContain("style=");
+    expect(payload.text).toContain("**Hello** there");
+    expect(payload.text).toContain("• item");
+  });
+});

--- a/src/tests/plain-text.test.ts
+++ b/src/tests/plain-text.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { htmlToPlainText } from "@/utils/plain-text";
+
+describe("htmlToPlainText", () => {
+  it("converts basic formatting to markdown-like syntax", () => {
+    const html = '<p><strong>Bold</strong> and <em>italic</em> plus <u>underline</u>.</p>';
+    const text = htmlToPlainText(html);
+    expect(text).toBe("**Bold** and *italic* plus _underline_.");
+  });
+
+  it("handles ordered and unordered lists", () => {
+    const html = '<p>Intro</p><ul><li>First</li><li>Second</li></ul><ol><li>One</li><li>Two</li></ol>';
+    const text = htmlToPlainText(html);
+    expect(text).toContain("Intro");
+    expect(text).toContain("• First\n• Second");
+    expect(text).toContain("1. One\n2. Two");
+  });
+});

--- a/src/tests/sanitize.test.ts
+++ b/src/tests/sanitize.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeHtml } from "@/utils/html";
+
+describe("sanitizeHtml", () => {
+  it("removes disallowed tags and attributes", () => {
+    const dirty = '<div style="color:red"><h1>Hello</h1><p data-test="x"><span>World</span></p></div>';
+    const clean = sanitizeHtml(dirty);
+    expect(clean).toContain("<p><strong>Hello</strong></p>");
+    expect(clean).toContain("<p>World</p>");
+    expect(clean).not.toContain("div");
+    expect(clean).not.toContain("style=");
+    expect(clean).not.toContain("span");
+  });
+
+  it("keeps links with rel and target and appends url to text", () => {
+    const dirty = '<a href="https://example.com">Example</a>';
+    const clean = sanitizeHtml(dirty);
+    expect(clean).toBe(
+      '<a href="https://example.com" rel="nofollow noopener" target="_blank">Example (https://example.com)</a>'
+    );
+  });
+});

--- a/src/utils/analysis.ts
+++ b/src/utils/analysis.ts
@@ -1,0 +1,125 @@
+import readingTime from "reading-time";
+import { spamPhrases } from "@/data/spam";
+
+export type QualityInsight = {
+  id: string;
+  label: string;
+  severity: "info" | "warn" | "error";
+};
+
+const CTA_KEYWORDS = [
+  "schedule",
+  "book",
+  "call",
+  "chat",
+  "walk",
+  "review",
+  "plan",
+  "map",
+  "start",
+  "ready",
+  "hire",
+  "next"
+];
+
+const QUESTION_WORDS = ["?", "how", "what", "when", "where", "which", "can you"];
+
+function tokenizeSentences(text: string) {
+  const sentences = text
+    .split(/[.!?]+\s/)
+    .map((sentence) => sentence.trim())
+    .filter(Boolean);
+  return sentences.length || !text.trim() ? sentences : [text.trim()];
+}
+
+function tokenizeWords(text: string) {
+  return text
+    .toLowerCase()
+    .match(/[a-zA-ZÀ-ÿ0-9']+/g)
+    ?.filter(Boolean) ?? [];
+}
+
+function countSyllables(word: string) {
+  const sanitized = word.toLowerCase();
+  if (sanitized.length <= 3) return 1;
+  const pattern = sanitized
+    .replace(/(?:[^laeiouy]|ed|[^laeiouy]e)$/g, "")
+    .replace(/^y/, "");
+  const matches = pattern.match(/[aeiouy]{1,2}/g);
+  return matches ? matches.length : 1;
+}
+
+export function fleschKincaidGrade(text: string) {
+  const sentences = tokenizeSentences(text);
+  const words = tokenizeWords(text);
+  if (!sentences.length || !words.length) return 0;
+
+  const syllables = words.reduce((total, word) => total + countSyllables(word), 0);
+  const avgWordsPerSentence = words.length / sentences.length;
+  const avgSyllablesPerWord = syllables / words.length;
+  const grade = 0.39 * avgWordsPerSentence + 11.8 * avgSyllablesPerWord - 15.59;
+  return Number.isFinite(grade) ? Number(Math.max(0, grade).toFixed(1)) : 0;
+}
+
+export function analyzeContent(text: string) {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  const wordCount = tokenizeWords(text).length;
+  const characterCount = text.replace(/\s/g, "").length;
+  const sentences = tokenizeSentences(text);
+  const avgSentenceLength = sentences.length ? wordCount / sentences.length : 0;
+  const readStats = readingTime(text || "0", { wordsPerMinute: 220 });
+
+  const hasQuestion = QUESTION_WORDS.some((token) =>
+    normalized.toLowerCase().includes(token)
+  );
+  const hasCta = CTA_KEYWORDS.some((token) =>
+    normalized.toLowerCase().includes(token)
+  );
+  const emojiMatches = text.match(/[\p{Emoji_Presentation}\p{Extended_Pictographic}]/gu) ?? [];
+
+  const hints: QualityInsight[] = [];
+  if (wordCount > 0 && wordCount / (text.split(/\n\n/).length || 1) > 160) {
+    hints.push({ id: "wall", label: "Break up the wall of text with shorter paragraphs.", severity: "warn" });
+  }
+  if (!hasQuestion) {
+    hints.push({ id: "question", label: "Add a clarifying question to show collaboration.", severity: "warn" });
+  }
+  if (!hasCta) {
+    hints.push({ id: "cta", label: "Close with a direct CTA (invite them to act).", severity: "error" });
+  }
+
+  const iCount = (text.match(/\b(i|we)\b/gi) ?? []).length;
+  const youCount = (text.match(/\byou\b/gi) ?? []).length;
+  if (youCount && iCount / youCount > 2.5) {
+    hints.push({ id: "pronoun", label: "Talk more about the client than yourself.", severity: "info" });
+  }
+  if (emojiMatches.length > 6) {
+    hints.push({ id: "emoji", label: "Ease up on the emojis for professional tone.", severity: "info" });
+  }
+
+  const spamMatches = spamPhrases.filter((phrase) =>
+    normalized.toLowerCase().includes(phrase)
+  );
+
+  const gradeLevel = fleschKincaidGrade(text);
+
+  let score = 100;
+  score -= Math.min(30, Math.max(0, avgSentenceLength - 22) * 1.5);
+  score -= hints.filter((hint) => hint.severity === "error").length * 25;
+  score -= hints.filter((hint) => hint.severity === "warn").length * 15;
+  score -= spamMatches.length * 5;
+  score = Math.max(0, Math.min(100, Math.round(score)));
+
+  return {
+    wordCount,
+    characterCount,
+    sentences: sentences.length,
+    avgSentenceLength: Number(avgSentenceLength.toFixed(1)),
+    readTimeMinutes: Math.max(1, Math.round(readStats.minutes * 10) / 10),
+    spamMatches,
+    hints,
+    score,
+    gradeLevel,
+    emojiCount: emojiMatches.length
+  };
+}

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,35 @@
+import { htmlToPlainText } from "@/utils/plain-text";
+import { sanitizeHtml } from "@/utils/html";
+
+export function buildClipboardPayload(html: string) {
+  const safeHtml = sanitizeHtml(html);
+  const plainText = htmlToPlainText(safeHtml);
+  return { html: safeHtml, text: plainText };
+}
+
+export async function copyToClipboard(html: string) {
+  const payload = buildClipboardPayload(html);
+  const supportsRichClipboard =
+    typeof navigator !== "undefined" &&
+    typeof window !== "undefined" &&
+    "clipboard" in navigator &&
+    "write" in navigator.clipboard &&
+    typeof window.ClipboardItem !== "undefined";
+
+  if (supportsRichClipboard) {
+    const data = [
+      new window.ClipboardItem({
+        "text/html": new Blob([payload.html], { type: "text/html" }),
+        "text/plain": new Blob([payload.text], { type: "text/plain" })
+      })
+    ];
+    await navigator.clipboard.write(data);
+    return payload;
+  }
+
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(payload.text);
+  }
+
+  return payload;
+}

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -1,0 +1,133 @@
+import createDOMPurify from "dompurify";
+import type { DOMPurifyI } from "dompurify";
+
+export const ALLOWED_TAGS = [
+  "p",
+  "br",
+  "strong",
+  "b",
+  "em",
+  "i",
+  "u",
+  "ul",
+  "ol",
+  "li",
+  "blockquote",
+  "code",
+  "pre",
+  "a"
+] as const;
+
+export type AllowedTag = (typeof ALLOWED_TAGS)[number];
+
+const allowedAttributes: Record<string, string[]> = {
+  a: ["href", "rel", "target"]
+};
+
+const purifierCache = new WeakMap<Window, DOMPurifyI>();
+
+function ensureEnv(): { window: Window & typeof globalThis; document: Document } {
+  if (typeof window !== "undefined" && typeof document !== "undefined") {
+    return { window: window as Window & typeof globalThis, document };
+  }
+
+  const jsdom = (eval("require")("jsdom") as typeof import("jsdom")).JSDOM;
+  const { window: jsdomWindow } = new jsdom(
+    "<!doctype html><html><body></body></html>",
+    {
+      url: "https://example.com"
+    }
+  );
+
+  return {
+    window: jsdomWindow as unknown as Window & typeof globalThis,
+    document: jsdomWindow.document
+  };
+}
+
+function getPurifier(win: Window & typeof globalThis) {
+  const existing = purifierCache.get(win);
+  if (existing) return existing;
+  const purifier = createDOMPurify(win);
+  purifierCache.set(win, purifier);
+  return purifier;
+}
+
+export function createDocumentFromHtml(html: string) {
+  const env = ensureEnv();
+  const doc = env.document.implementation.createHTMLDocument("");
+  doc.body.innerHTML = html;
+  return { document: doc, window: env.window };
+}
+
+export function sanitizeHtml(html: string) {
+  const normalized = html
+    .replace(/<h[1-6][^>]*>(.*?)<\/h[1-6]>/gis, "<p><strong>$1</strong></p>")
+    .replace(/<div[^>]*>/gi, "<p>")
+    .replace(/<\/div>/gi, "</p>");
+  const env = ensureEnv();
+  const purifier = getPurifier(env.window);
+
+  const sanitized = purifier.sanitize(normalized, {
+    ALLOWED_TAGS: [...ALLOWED_TAGS],
+    ALLOWED_ATTR: allowedAttributes,
+    USE_PROFILES: { html: false },
+    KEEP_CONTENT: false,
+    FORBID_ATTR: ["style", "class", "id"],
+    RETURN_DOM: false
+  });
+
+  const { document: doc } = createDocumentFromHtml(sanitized as string);
+
+  Array.from(doc.body.childNodes).forEach((node) => {
+    if (node.nodeType === env.window.Node.TEXT_NODE) {
+      const text = node.textContent?.trim();
+      if (text) {
+        const paragraph = doc.createElement("p");
+        paragraph.textContent = text;
+        node.parentNode?.replaceChild(paragraph, node);
+      } else {
+        node.parentNode?.removeChild(node);
+      }
+    }
+  });
+
+  doc.querySelectorAll("a").forEach((anchor) => {
+    const href = anchor.getAttribute("href");
+    if (!href) {
+      anchor.replaceWith(anchor.textContent ?? "");
+      return;
+    }
+
+    anchor.setAttribute("rel", "nofollow noopener");
+    anchor.setAttribute("target", "_blank");
+
+    const text = anchor.textContent?.trim() ?? "";
+    if (!text || !text.includes(href)) {
+      anchor.textContent = text ? `${text} (${href})` : href;
+    }
+  });
+
+  doc.querySelectorAll("li").forEach((item) => {
+    if (!item.textContent?.trim()) return;
+    if (!item.innerHTML.startsWith("\u200B")) {
+      item.innerHTML = `\u200B${item.innerHTML}`;
+    }
+    if (!item.innerHTML.endsWith("\u200B")) {
+      item.innerHTML = `${item.innerHTML}\u200B`;
+    }
+  });
+
+  return doc.body.innerHTML;
+}
+
+export function sanitizeForPreview(html: string) {
+  const clean = sanitizeHtml(html);
+  const { document: doc } = createDocumentFromHtml(clean);
+
+  doc.querySelectorAll("code").forEach((node) => {
+    node.setAttribute("style", "");
+  });
+
+  return doc.body.innerHTML;
+}

--- a/src/utils/plain-text.ts
+++ b/src/utils/plain-text.ts
@@ -1,0 +1,109 @@
+import { createDocumentFromHtml } from "@/utils/html";
+
+function renderInline(node: Node): string {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.textContent ?? "";
+  }
+
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return "";
+  }
+
+  const element = node as HTMLElement;
+  const content = Array.from(element.childNodes)
+    .map((child) => renderInline(child))
+    .join("");
+
+  switch (element.tagName) {
+    case "STRONG":
+    case "B":
+      return content ? `**${content}**` : content;
+    case "EM":
+    case "I":
+      return content ? `*${content}*` : content;
+    case "U":
+      return content ? `_${content}_` : content;
+    case "CODE":
+      if (element.parentElement?.tagName === "PRE") {
+        return content;
+      }
+      return content ? `\`${content}\`` : content;
+    case "A": {
+      const href = element.getAttribute("href") ?? "";
+      const text = content.trim() || href;
+      return href ? `${text} (${href})` : text;
+    }
+    case "BR":
+      return "\n";
+    default:
+      return content;
+  }
+}
+
+function renderList(items: Element[], ordered = false) {
+  return items
+    .map((item, index) => {
+      const marker = ordered ? `${index + 1}.` : "•";
+      const text = Array.from(item.childNodes)
+        .map((child) => renderInline(child))
+        .join("")
+        .replace(/\u200B/g, "")
+        .trim();
+      return text ? `${marker} ${text}` : "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function renderBlock(node: Node): string[] {
+  if (node.nodeType === Node.TEXT_NODE) {
+    const text = node.textContent?.trim();
+    return text ? [text] : [];
+  }
+
+  if (node.nodeType !== Node.ELEMENT_NODE) return [];
+
+  const element = node as HTMLElement;
+  switch (element.tagName) {
+    case "P": {
+      const line = Array.from(element.childNodes)
+        .map((child) => renderInline(child))
+        .join("")
+        .replace(/\u200B/g, "")
+        .trim();
+      return line ? [line] : [];
+    }
+    case "UL":
+      return renderList(Array.from(element.children), false)
+        .split("\n")
+        .filter(Boolean);
+    case "OL":
+      return renderList(Array.from(element.children), true)
+        .split("\n")
+        .filter(Boolean);
+    case "BLOCKQUOTE": {
+      const inner = Array.from(element.childNodes)
+        .flatMap((child) => renderBlock(child))
+        .map((line) => `> ${line}`);
+      return inner;
+    }
+    case "PRE": {
+      const code = element.textContent ?? "";
+      return ["```", code.trimEnd(), "```"];
+    }
+    case "BR":
+      return [""];
+    default:
+      return Array.from(element.childNodes).flatMap((child) => renderBlock(child));
+  }
+}
+
+export function htmlToPlainText(html: string) {
+  const { document } = createDocumentFromHtml(html);
+  const blocks = Array.from(document.body.childNodes).flatMap((node) =>
+    renderBlock(node)
+  );
+
+  const cleaned = blocks.join("\n\n");
+  return cleaned.replace(/\n{3,}/g, "\n\n").trimEnd();
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,31 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./src/app/**/*.{ts,tsx}",
+    "./src/components/**/*.{ts,tsx}",
+    "./src/features/**/*.{ts,tsx}",
+    "./src/**/*.mdx"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        muted: "hsl(var(--muted))",
+        "muted-foreground": "hsl(var(--muted-foreground))",
+        accent: "hsl(var(--accent))",
+        "accent-foreground": "hsl(var(--accent-foreground))",
+        border: "hsl(var(--border))",
+        ring: "hsl(var(--ring))"
+      },
+      fontFamily: {
+        sans: ["var(--font-sans)"]
+      }
+    }
+  },
+  plugins: [require("tailwindcss-animate")]
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src")
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Next.js + TypeScript workspace with Tailwind and shadcn-style primitives
- implement the proposal editor experience with TipTap, Upwork preview, copy helpers, templates, variables, snippets, and quality assistant insights
- add sanitisation utilities, clipboard payload builders, plain-text renderer, and supporting tests plus a how-to guide

## Testing
- `npm test` *(fails: vitest not installed because npm install is blocked by 403 registry policy)*

------
https://chatgpt.com/codex/tasks/task_e_68caf7cb5f08832993504a666a452e07

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced Proposal Editor with templates, sections, snippets, variables, and rich toolbar (links, lists, code, emoji).
  - Quality panel with readability metrics, spam checks, and score.
  - Copy to clipboard in Upwork-safe HTML or styled plain text.
  - Sanitized live preview, paste tester sandbox, and auto-save.
  - Site layout with header navigation, dark mode toggle, and “How to Paste into Upwork” guide.

- Documentation
  - Rewrote README with setup, scripts, features, and testing instructions.

- Tests
  - Added tests for HTML sanitization, clipboard payloads, and plain-text rendering.

- Chores
  - Set up Next.js, TypeScript, Tailwind, ESLint, PostCSS, and Vitest configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->